### PR TITLE
ethash interface to speed smartpool compilation on etherscan

### DIFF
--- a/contracts/Ethash.sol
+++ b/contracts/Ethash.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.17;
 //solc --bin --abi --optimize  --optimize-runs 20000 -o . Testpool.sol
 
 
-//import "./SHA3_512.sol";
+import "./EthashInterface.sol";
 
 contract SHA3_512 {
     function SHA3_512() public {}
@@ -217,7 +217,7 @@ contract SHA3_512 {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-contract Ethash is SHA3_512 {
+contract Ethash is SHA3_512, EthashInterface {
 
     mapping(address=>bool) public owners;
 

--- a/contracts/EthashInterface.sol
+++ b/contracts/EthashInterface.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.4.17;
+
+interface EthashInterface {
+
+    function isEpochDataSet( uint epochIndex ) public constant returns(bool);
+    function hashimoto( bytes32      header,
+                        bytes8       nonceLe,
+                        uint[]       dataSetLookup,
+                        uint[]       witnessForLookup,
+                        uint         epochIndex ) public constant returns(uint);
+}

--- a/contracts/SmartPool.sol
+++ b/contracts/SmartPool.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.17;
 //solc --bin --abi --optimize  --optimize-runs 20000 -o . Testpool.sol
 
 
-import "./Ethash.sol";
+import "./EthashInterface.sol";
 
 /**
 * @title RLPReader
@@ -855,7 +855,7 @@ contract WeightedSubmission {
 contract SmartPool is Agt, WeightedSubmission {
     string  public version = "0.1.1";
 
-    Ethash  public ethashContract;
+    EthashInterface  public ethashContract;
     address public withdrawalAddress;
     mapping(address=>bool) public owners;
 
@@ -875,7 +875,7 @@ contract SmartPool is Agt, WeightedSubmission {
     mapping(address=>bool) blackList;
 
     function SmartPool( address[] _owners,
-                        Ethash _ethashContract,
+                        EthashInterface _ethashContract,
                         address _withdrawalAddress,
                         bool _whiteListEnabled,
                         bool _blackListEnabled ) public payable {


### PR DESCRIPTION
Create ethash interface in order to speed smartpool compilation.
Without it, etherscan will not allow us to verify the code, as it takes too much time to compile the contract.
This also suppose to save gas in deployment.