### PR TITLE
Fix short address decoding (develop branch)

### DIFF
--- a/contracts/SmartPool.sol
+++ b/contracts/SmartPool.sol
@@ -302,14 +302,10 @@ library RLP {
  /// @param self The RLPItem.
  /// @return The decoded string.
  function toAddress(RLPItem memory self) internal pure returns (address data) {
-     if(!isData(self))
+     var (, len) = _decode(self);
+     if (len > 20)
          revert();
-     var (rStartPos, len) = _decode(self);
-     if (len != 20)
-         revert();
-     assembly {
-         data := div(mload(rStartPos), exp(256, 12))
-     }
+     return address(toUint(self));
  }
 
  // Get the payload offset.


### PR DESCRIPTION
Example addresses:
```
0x0014F55A50b281EFD12294f0Cda821Bd8171e920
0x0000000000000000000000000000000000000000
```